### PR TITLE
task-1 create private gke cluster

### DIFF
--- a/gcp_test/README.md
+++ b/gcp_test/README.md
@@ -1,0 +1,1 @@
+# gcp_test

--- a/gcp_test/terraform/gke.tf
+++ b/gcp_test/terraform/gke.tf
@@ -1,0 +1,48 @@
+
+resource "google_container_cluster" "private" {
+  name                     = "my-gke-cluster"
+  location                 = var.region
+  initial_node_count       = 1
+  project                  = var.project_id
+  remove_default_node_pool = true
+  network                  = var.network
+  subnetwork = google_compute_subnetwork.gke-network-subnet.self_link
+  private_cluster_config {
+    enable_private_nodes   = true
+    master_ipv4_cidr_block = "192.168.0.0/28"
+  }
+  ip_allocation_policy {
+    cluster_secondary_range_name  = var.gke_pod_range_name
+    services_secondary_range_name = var.gke_service_range_name
+  }
+}
+
+resource "google_container_node_pool" "primary-node" {
+  name       = "my-node-pool1"
+  location   = var.region
+  cluster    = google_container_cluster.private.name
+  node_count = 3
+  node_config {
+    service_account = "gcp-test@careful-sun-379910.iam.gserviceaccount.com"
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
+
+}
+
+resource "google_container_node_pool" "secondary-node" {
+  name     = "my-node-pool2"
+  location = var.region
+  cluster  = google_container_cluster.private.name
+  node_config {
+    preemptible     = true
+    service_account = "gcp-test@careful-sun-379910.iam.gserviceaccount.com"
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
+  autoscaling {
+    max_node_count = 4
+  }
+}

--- a/gcp_test/terraform/nat.tf
+++ b/gcp_test/terraform/nat.tf
@@ -1,0 +1,22 @@
+resource "google_compute_router" "outbound-router" {
+  name    = "outbound-router"
+  region  = var.region
+  network = var.network
+
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_nat" "outbound-gke-nat" {
+  name                               = "outbound-gke-nat"
+  router                             = google_compute_router.outbound-router.name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}

--- a/gcp_test/terraform/network.tf
+++ b/gcp_test/terraform/network.tf
@@ -1,0 +1,15 @@
+resource "google_compute_network" "gke-network" {
+  auto_create_subnetworks         = "false"
+  name                            = "gke-network"
+  project                         = var.project_id
+  routing_mode                    = "GLOBAL"
+}
+
+resource "google_compute_subnetwork" "gke-network-subnet" {
+  ip_cidr_range              = "192.168.0.0/24"
+  name                       = "gke-network-subnet"
+  network                    = google_compute_network.gke-network.self_link
+  secondary_ip_range         = var.subnet_secondary_cidr
+  project                    = var.project_id
+  region                     = var.region
+}

--- a/gcp_test/terraform/provider.tf
+++ b/gcp_test/terraform/provider.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "4.51.0"
+    }
+  }
+}
+
+provider "google" {
+  credentials = file("careful-sun-379910-84e5417b71a1.json")
+
+  project = "careful-sun-379910"
+  region  = var.region
+}

--- a/gcp_test/terraform/terraform.tfvars
+++ b/gcp_test/terraform/terraform.tfvars
@@ -1,0 +1,15 @@
+region     = "europe-west2"
+project_id = "careful-sun-379910"
+network    = "https://www.googleapis.com/compute/v1/projects/careful-sun-379910/global/networks/gke-network"
+subnet_secondary_cidr = [
+  {
+    range_name    = "pod"
+    ip_cidr_range = "10.0.1.0/24"
+  },
+  {
+    range_name    = "service"
+    ip_cidr_range = "10.4.1.0/24"
+  }
+]
+gke_pod_range_name                      = "pod"
+gke_service_range_name                  = "service"

--- a/gcp_test/terraform/variables.tf
+++ b/gcp_test/terraform/variables.tf
@@ -1,0 +1,21 @@
+variable "region" {
+  type = string
+}
+variable "project_id" {
+  type = string
+}
+
+variable "network" {
+  type = string
+}
+
+variable "subnet_secondary_cidr" {
+  type = list(any)
+}
+
+variable "gke_pod_range_name" {
+  type = string
+}
+variable "gke_service_range_name" {
+  type = string
+}


### PR DESCRIPTION
## Task 1
Start a new Terraform working directory satisfying the following requirements
1. Provision a regional `private` K8s cluster on GKE
2. A dedicated service account should be used (instead of the default one), and the service account should be created as part of the script 
3. It should be creating a `new VPC` instead of using the default one
4. Subnet should be created in the `London` region, and the cluster should use this subnet. Make sure CIDR ranges used by the cluster are in the `RFC1918 24-bit block`
5. Create two node-pools, one with 3 nodes without auto-scaling, another with 0 node by default with auto-scaling enabled. Allow the auto-scaling node-pool to use preemptible nodes4.
6. Allow outbound internet access to the private cluster without assigning externalIP addresses to it